### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Http/Request/Fopen.php
+++ b/lib/Horde/Http/Request/Fopen.php
@@ -144,8 +144,7 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
      * @param integer $errline   See set_error_handler().
      * @param array $errcontext  See set_error_handler().
      */
-    protected function _errorHandler($errno, $errstr, $errfile, $errline,
-                                     $errcontext)
+    protected function _errorHandler($errno, $errstr, $errfile, $errline)
     {
         array_unshift($this->_errors, preg_replace('/^(.*?) \[<a href[^\]]*\](.*)/', '$1$2', $errstr));
     }

--- a/lib/Horde/Http/Request/Peclhttp2.php
+++ b/lib/Horde/Http/Request/Peclhttp2.php
@@ -75,7 +75,7 @@ class Horde_Http_Request_Peclhttp2 extends Horde_Http_Request_PeclhttpBase
         if (is_array($data)) {
             $body->addForm($data);
         } else {
-            $body->append($data);
+            $body->append(is_null($data) ? "" : $data);
         }
 
         $httpRequest = new \http\Client\Request($this->method, (string)$this->uri, $this->headers, $body);

--- a/lib/Horde/Http/Response/Mock.php
+++ b/lib/Horde/Http/Response/Mock.php
@@ -20,6 +20,7 @@
  * @license   http://www.horde.org/licenses/bsd BSD
  * @package   Http
  */
+#[AllowDynamicProperties]
 class Horde_Http_Response_Mock extends Horde_Http_Response_Base
 {
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Http/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Http/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Http Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Http/ClientTest.php
+++ b/test/Horde/Http/ClientTest.php
@@ -34,11 +34,9 @@ class Horde_Http_ClientTest extends Horde_Test_Case
         $this->assertEquals(10, $request->timeout);
     }
 
-    /**
-     * @expectedException Horde_Http_Exception
-     */
     public function testSetUnknownOption()
     {
+        $this->expectException('Horde_Http_Exception');
         $request = new Horde_Http_Request_Mock();
         $client = new Horde_Http_Client(
             array('request' => $request)

--- a/test/Horde/Http/CurlTest.php
+++ b/test/Horde/Http/CurlTest.php
@@ -18,7 +18,7 @@
  */
 class Horde_Http_CurlTest extends Horde_Http_TestBase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!function_exists('curl_exec')) {
             $this->markTestSkipped('Missing PHP extension "curl"!');

--- a/test/Horde/Http/MockTest.php
+++ b/test/Horde/Http/MockTest.php
@@ -24,7 +24,7 @@
  * @license    http://www.horde.org/licenses/bsd
  * @link       http://www.horde.org/libraries/Horde_Http
  */
-class Horde_Http_MockTest extends PHPUnit_Framework_TestCase
+class Horde_Http_MockTest extends Horde_Test_Case
 {
     public function testNoResponses()
     {

--- a/test/Horde/Http/Peclhttp2Test.php
+++ b/test/Horde/Http/Peclhttp2Test.php
@@ -18,7 +18,7 @@
  */
 class Horde_Http_Peclhttp2Test extends Horde_Http_TestBase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\http\Client', false)) {
             $this->markTestSkipped('Missing PHP extension "http" or wrong version!');

--- a/test/Horde/Http/PeclhttpTest.php
+++ b/test/Horde/Http/PeclhttpTest.php
@@ -18,7 +18,7 @@
  */
 class Horde_Http_PeclhttpTest extends Horde_Http_TestBase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('HttpRequest', false)) {
             $this->markTestSkipped('Missing PHP extension "http" or wrong version!');

--- a/test/Horde/Http/TestBase.php
+++ b/test/Horde/Http/TestBase.php
@@ -22,13 +22,13 @@ class Horde_Http_TestBase extends Horde_Test_Case
 
     protected static $_requestClass;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         preg_match('/Horde_Http_(.*)Test/', get_called_class(), $match);
         self::$_requestClass = 'Horde_Http_Request_' . $match[1];
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $config = self::getConfig('HTTP_TEST_CONFIG');
         if ($config && !empty($config['http']['server'])) {
@@ -47,10 +47,10 @@ class Horde_Http_TestBase extends Horde_Test_Case
         $this->assertStringStartsWith('http', $response->uri);
         $this->assertStringStartsWith('1.', $response->httpVersion);
         $this->assertEquals(200, $response->code);
-        $this->assertInternalType('array', $response->headers);
-        $this->assertInternalType('string', $response->getBody());
+        $this->assertIsArray($response->headers);
+        $this->assertIsString($response->getBody());
         $this->assertGreaterThan(0, strlen($response->getBody()));
-        $this->assertInternalType('resource', $response->getStream());
+        $this->assertIsResource($response->getStream());
         $this->assertStringMatchesFormat(
             '%s/%s',
             $response->getHeader('Content-Type')
@@ -66,22 +66,18 @@ class Horde_Http_TestBase extends Horde_Test_Case
         );
     }
 
-    /**
-     * @expectedException Horde_Http_Exception
-     */
     public function testThrowsOnBadUri()
     {
+        $this->expectException('Horde_Http_Exception');
         $client = new Horde_Http_Client(
             array('request' => new self::$_requestClass())
         );
         $client->get('http://doesntexist/');
     }
 
-    /**
-     * @expectedException Horde_Http_Exception
-     */
     public function testThrowsOnInvalidProxyType()
     {
+        $this->expectException('Horde_Http_Exception');
         $client = new Horde_Http_Client(
             array(
                 'request' => new self::$_requestClass(


### PR DESCRIPTION
- Debian changes:  Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-http/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes:  Add 1012_php8.2.patch. Fix PHP 8.2 deprecation warnings. (Closes: #1028933). https://salsa.debian.org/horde-team/php-horde-http/-/blob/debian-sid/debian/patches/1012_php8.2.patch
