### PR TITLE
fix(http): resolve dynamic property deprecation in Mock client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ composer.lock
 /phpstan.neon
 # PHPStan cache directory
 /.phpstan.cache/
+
+# Added by horde-components QC --fix-qc-issues
+# Horde installer plugin runtime data
+/var/
+# Horde installer plugin web-accessible directory
+/web/

--- a/.horde.yml
+++ b/.horde.yml
@@ -52,3 +52,4 @@ vendor: horde
 quality:
   phpstan:
     level: 9
+keywords: []

--- a/lib/Horde/Http.php
+++ b/lib/Horde/Http.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -25,16 +26,16 @@ class Horde_Http
     /**
      * Authentication schemes
      */
-    const AUTH_ANY = 'ANY';
-    const AUTH_BASIC = 'BASIC';
-    const AUTH_DIGEST = 'DIGEST';
-    const AUTH_NTLM = 'NTLM';
-    const AUTH_GSSNEGOTIATE = 'GSSNEGOTIATE';
+    public const AUTH_ANY = 'ANY';
+    public const AUTH_BASIC = 'BASIC';
+    public const AUTH_DIGEST = 'DIGEST';
+    public const AUTH_NTLM = 'NTLM';
+    public const AUTH_GSSNEGOTIATE = 'GSSNEGOTIATE';
 
     /**
      * Proxy types
      */
-    const PROXY_HTTP = 0;
-    const PROXY_SOCKS4 = 1;
-    const PROXY_SOCKS5 = 2;
+    public const PROXY_HTTP = 0;
+    public const PROXY_SOCKS4 = 1;
+    public const PROXY_SOCKS5 = 2;
 }

--- a/lib/Horde/Http/Client.php
+++ b/lib/Horde/Http/Client.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -99,7 +100,7 @@ class Horde_Http_Client
      *                    constructor. See the class properties for available
      *                    settings.
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         // Set or create request object
         if (isset($args['request'])) {
@@ -124,7 +125,7 @@ class Horde_Http_Client
      * @throws Horde_Http_Exception
      * @return Horde_Http_Response_Base
      */
-    public function get($uri = null, $headers = array())
+    public function get($uri = null, $headers = [])
     {
         return $this->request('GET', $uri, null, $headers);
     }
@@ -139,7 +140,7 @@ class Horde_Http_Client
      * @throws Horde_Http_Exception
      * @return Horde_Http_Response_Base
      */
-    public function post($uri = null, $data = null, $headers = array())
+    public function post($uri = null, $data = null, $headers = [])
     {
         return $this->request('POST', $uri, $data, $headers);
     }
@@ -154,11 +155,11 @@ class Horde_Http_Client
      * @throws Horde_Http_Exception
      * @return Horde_Http_Response_Base
      */
-    public function put($uri = null, $data = null, $headers = array())
+    public function put($uri = null, $data = null, $headers = [])
     {
         if ($this->_httpMethodOverride) {
             $headers = array_merge(
-                array('X-HTTP-Method-Override' => 'PUT'),
+                ['X-HTTP-Method-Override' => 'PUT'],
                 $headers
             );
             return $this->post($uri, $data, $headers);
@@ -176,11 +177,11 @@ class Horde_Http_Client
      * @throws Horde_Http_Exception
      * @return Horde_Http_Response_Base
      */
-    public function delete($uri = null, $headers = array())
+    public function delete($uri = null, $headers = [])
     {
         if ($this->_httpMethodOverride) {
             $headers = array_merge(
-                array('X-HTTP-Method-Override' => 'DELETE'),
+                ['X-HTTP-Method-Override' => 'DELETE'],
                 $headers
             );
             return $this->post($uri, null, $headers);
@@ -198,7 +199,7 @@ class Horde_Http_Client
      * @throws Horde_Http_Exception
      * @return Horde_Http_Response_Base
      */
-    public function head($uri = null, $headers = array())
+    public function head($uri = null, $headers = [])
     {
         return $this->request('HEAD', $uri, null, $headers);
     }
@@ -220,9 +221,11 @@ class Horde_Http_Client
      * @return Horde_Http_Response_Base
      */
     public function request(
-        $method, $uri = null, $data = null, $headers = array()
-    )
-    {
+        $method,
+        $uri = null,
+        $data = null,
+        $headers = []
+    ) {
         if ($method !== null) {
             $this->request->method = $method;
         }
@@ -251,7 +254,7 @@ class Horde_Http_Client
      */
     public function __get($name)
     {
-        return isset($this->{'_' . $name}) ? $this->{'_' . $name} : null;
+        return $this->{'_' . $name} ?? null;
     }
 
     /**
@@ -271,7 +274,7 @@ class Horde_Http_Client
             }
         }
 
-        list($object, $objectkey) = explode('.', $name, 2);
+        [$object, $objectkey] = explode('.', $name, 2);
         if ($object == 'request') {
             $this->$object->$objectkey = $value;
             return true;

--- a/lib/Horde/Http/Exception.php
+++ b/lib/Horde/Http/Exception.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -20,6 +21,4 @@
  * @license   http://www.horde.org/licenses/bsd BSD
  * @package   Http
  */
-class Horde_Http_Exception extends Horde_Exception_Wrapped
-{
-}
+class Horde_Http_Exception extends Horde_Exception_Wrapped {}

--- a/lib/Horde/Http/Request/Base.php
+++ b/lib/Horde/Http/Request/Base.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -49,29 +50,29 @@ abstract class Horde_Http_Request_Base
      * Request headers
      * @var array
      */
-    protected $_headers = array();
+    protected $_headers = [];
 
     /**
      * @var array
      */
-    protected $_options = array();
+    protected $_options = [];
 
     /**
      * Constructor
      */
-    public function __construct($options = array())
+    public function __construct($options = [])
     {
         $this->setOptions($options);
     }
 
-    public function setOptions($options = array())
+    public function setOptions($options = [])
     {
         $this->_options = array_merge($this->getDefaultOptions(), $options);
     }
 
     public function getDefaultOptions()
     {
-        return array(
+        return [
             'uri' => null,
             'method' => 'GET',
             'data' => null,
@@ -88,7 +89,7 @@ abstract class Horde_Http_Request_Base
             'timeout' => 5,
             'userAgent' => str_replace(' @' . 'version@', '', 'Horde_Http @version@'),
             'verifyPeer' => true,
-        );
+        ];
     }
 
     /**
@@ -108,11 +109,11 @@ abstract class Horde_Http_Request_Base
     public function __get($name)
     {
         switch ($name) {
-        case 'headers':
-            return $this->_headers;
+            case 'headers':
+                return $this->_headers;
         }
 
-        return isset($this->_options[$name]) ? $this->_options[$name] : null;
+        return $this->_options[$name] ?? null;
     }
 
     /**
@@ -124,9 +125,9 @@ abstract class Horde_Http_Request_Base
     public function __set($name, $value)
     {
         switch ($name) {
-        case 'headers':
-            $this->setHeaders($value);
-            break;
+            case 'headers':
+                $this->setHeaders($value);
+                break;
         }
 
         $this->_options[$name] = $value;
@@ -141,7 +142,7 @@ abstract class Horde_Http_Request_Base
     public function setHeaders($headers, $value = null)
     {
         if (!is_array($headers)) {
-            $headers = array($headers => $value);
+            $headers = [$headers => $value];
         }
 
         foreach ($headers as $header => $value) {
@@ -157,6 +158,6 @@ abstract class Horde_Http_Request_Base
      */
     public function getHeader($header)
     {
-        return isset($this->_headers[$header]) ? $this->_headers[$header] : null;
+        return $this->_headers[$header] ?? null;
     }
 }

--- a/lib/Horde/Http/Request/Curl.php
+++ b/lib/Horde/Http/Request/Curl.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -28,20 +29,20 @@ class Horde_Http_Request_Curl extends Horde_Http_Request_Base
      *
      * @var array
      */
-    protected $_httpAuthSchemes = array(
+    protected $_httpAuthSchemes = [
         Horde_Http::AUTH_ANY => CURLAUTH_ANY,
         Horde_Http::AUTH_BASIC => CURLAUTH_BASIC,
         Horde_Http::AUTH_DIGEST => CURLAUTH_DIGEST,
         Horde_Http::AUTH_GSSNEGOTIATE => CURLAUTH_GSSNEGOTIATE,
         Horde_Http::AUTH_NTLM => CURLAUTH_NTLM,
-    );
+    ];
 
     /**
      * Constructor
      *
      * @throws Horde_Http_Exception
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         if (!extension_loaded('curl')) {
             throw new Horde_Http_Exception('The curl extension is not installed. See http://php.net/curl.installation');
@@ -59,7 +60,7 @@ class Horde_Http_Request_Curl extends Horde_Http_Request_Base
     public function send()
     {
         $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, (string)$this->uri);
+        curl_setopt($curl, CURLOPT_URL, (string) $this->uri);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_HEADER, true);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $this->method);
@@ -102,7 +103,7 @@ class Horde_Http_Request_Curl extends Horde_Http_Request_Base
             }
             if ($this->proxyType == Horde_Http::PROXY_SOCKS5) {
                 curl_setopt($curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
-            } else if ($this->proxyType != Horde_Http::PROXY_HTTP) {
+            } elseif ($this->proxyType != Horde_Http::PROXY_HTTP) {
                 throw new Horde_Http_Exception(sprintf('Proxy type %s not supported by this request type!', $this->proxyType));
             }
         }
@@ -114,7 +115,7 @@ class Horde_Http_Request_Curl extends Horde_Http_Request_Base
         }
 
         // Concatenate the headers
-        $hdr = array();
+        $hdr = [];
         $headers = $this->headers;
         if (empty($headers['Expect'])) {
             $headers['Expect'] = '';
@@ -130,7 +131,7 @@ class Horde_Http_Request_Curl extends Horde_Http_Request_Base
             throw new Horde_Http_Exception(curl_error($curl), curl_errno($curl));
         }
         $info = curl_getinfo($curl);
-        return new Horde_Http_Response_Curl((string)$this->uri, $result, $info);
+        return new Horde_Http_Response_Curl((string) $this->uri, $result, $info);
     }
 
     /**

--- a/lib/Horde/Http/Request/Factory.php
+++ b/lib/Horde/Http/Request/Factory.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.

--- a/lib/Horde/Http/Request/Fopen.php
+++ b/lib/Horde/Http/Request/Fopen.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -30,14 +31,14 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
      *
      * @var array
      */
-    protected $_errors = array();
+    protected $_errors = [];
 
     /**
      * Constructor
      *
      * @throws Horde_Http_Exception
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         if (!ini_get('allow_url_fopen')) {
             throw new Horde_Http_Exception('allow_url_fopen must be enabled');
@@ -55,14 +56,14 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
     public function send()
     {
         $method = $this->method;
-        $uri = (string)$this->uri;
+        $uri = (string) $this->uri;
         $headers = $this->headers;
         $data = $this->data;
         if (is_array($data)) {
             $data = http_build_query($data, '', '&');
         }
 
-        $opts = array('http' => array());
+        $opts = ['http' => []];
 
         // Proxy settings
         if ($this->proxyServer) {
@@ -83,13 +84,13 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
         // Authentication settings
         if ($this->username) {
             switch ($this->authenticationScheme) {
-            case Horde_Http::AUTH_BASIC:
-            case Horde_Http::AUTH_ANY:
-                $headers['Authorization'] = 'Basic ' . base64_encode($this->username . ':' . $this->password);
-                break;
+                case Horde_Http::AUTH_BASIC:
+                case Horde_Http::AUTH_ANY:
+                    $headers['Authorization'] = 'Basic ' . base64_encode($this->username . ':' . $this->password);
+                    break;
 
-            default:
-                throw new Horde_Http_Exception('Unsupported authentication scheme (' . $this->authenticationScheme . ')');
+                default:
+                    throw new Horde_Http_Exception('Unsupported authentication scheme (' . $this->authenticationScheme . ')');
             }
         }
 
@@ -99,7 +100,7 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
         }
 
         // Concatenate the headers
-        $hdr = array();
+        $hdr = [];
         foreach ($headers as $header => $value) {
             $hdr[] = $header . ': ' . $value;
         }
@@ -116,12 +117,12 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
         $opts['ssl']['allow_self_signed'] = true;
 
         $context = stream_context_create($opts);
-        set_error_handler(array($this, '_errorHandler'), E_WARNING | E_NOTICE);
+        set_error_handler([$this, '_errorHandler'], E_WARNING | E_NOTICE);
         $stream = fopen($uri, 'rb', false, $context);
         restore_error_handler();
         if (!$stream) {
-            if (isset($this->_errors[0]['message']) &&
-                preg_match('/HTTP\/(\d+\.\d+) (\d{3}) (.*)$/', $this->_errors[0]['message'], $matches)) {
+            if (isset($this->_errors[0]['message'])
+                && preg_match('/HTTP\/(\d+\.\d+) (\d{3}) (.*)$/', $this->_errors[0]['message'], $matches)) {
                 // Create a Response for the HTTP error code
                 return new Horde_Http_Response_Fopen($uri, null, $matches[0]);
             } else {
@@ -130,7 +131,7 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
         }
 
         $meta = stream_get_meta_data($stream);
-        $headers = isset($meta['wrapper_data']) ? $meta['wrapper_data'] : array();
+        $headers = $meta['wrapper_data'] ?? [];
 
         return new Horde_Http_Response_Fopen($uri, $stream, $headers);
     }
@@ -144,9 +145,13 @@ class Horde_Http_Request_Fopen extends Horde_Http_Request_Base
      * @param integer $errline   See set_error_handler().
      * @param array $errcontext  See set_error_handler().
      */
-    protected function _errorHandler($errno, $errstr, $errfile, $errline,
-                                     $errcontext)
-    {
+    protected function _errorHandler(
+        $errno,
+        $errstr,
+        $errfile,
+        $errline,
+        $errcontext
+    ) {
         array_unshift($this->_errors, preg_replace('/^(.*?) \[<a href[^\]]*\](.*)/', '$1$2', $errstr));
     }
 }

--- a/lib/Horde/Http/Request/Mock.php
+++ b/lib/Horde/Http/Request/Mock.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -29,7 +30,7 @@ class Horde_Http_Request_Mock extends Horde_Http_Request_Base
      *
      * @var array
      */
-    protected $_responses = array();
+    protected $_responses = [];
 
     /**
      * Send this HTTP request
@@ -56,7 +57,7 @@ class Horde_Http_Request_Mock extends Horde_Http_Request_Base
      */
     public function setResponse(Horde_Http_Response_Base $response)
     {
-        $this->_responses = array($response);
+        $this->_responses = [$response];
     }
 
     /**
@@ -74,10 +75,10 @@ class Horde_Http_Request_Mock extends Horde_Http_Request_Base
             }
             if (is_array($response)) {
                 $this->addResponse(
-                    isset($response['body']) ? $response['body'] : '',
-                    isset($response['code']) ? $response['code'] : 200,
-                    isset($response['uri']) ? $response['uri'] : '',
-                    isset($response['headers']) ? $response['headers'] : array()
+                    $response['body'] ?? '',
+                    $response['code'] ?? 200,
+                    $response['uri'] ?? '',
+                    $response['headers'] ?? []
                 );
             }
         }
@@ -97,13 +98,17 @@ class Horde_Http_Request_Mock extends Horde_Http_Request_Base
      * @return Horde_Http_Response_Mock The response.
      */
     public function addResponse(
-        $body, $code = 200, $uri = '', $headers = array()
-    )
-    {
+        $body,
+        $code = 200,
+        $uri = '',
+        $headers = []
+    ) {
         if (is_string($body)) {
             $stream = new Horde_Support_StringStream($body);
             $response = new Horde_Http_Response_Mock(
-                $uri, $stream->fopen(), $headers
+                $uri,
+                $stream->fopen(),
+                $headers
             );
         } else {
             $response = new Horde_Http_Response_Mock($uri, $body, $headers);

--- a/lib/Horde/Http/Request/Peclhttp.php
+++ b/lib/Horde/Http/Request/Peclhttp.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -28,20 +29,20 @@ class Horde_Http_Request_Peclhttp extends Horde_Http_Request_PeclhttpBase
      *
      * @var array
      */
-    protected $_httpAuthSchemes = array(
+    protected $_httpAuthSchemes = [
         Horde_Http::AUTH_ANY => HTTP_AUTH_ANY,
         Horde_Http::AUTH_BASIC => HTTP_AUTH_BASIC,
         Horde_Http::AUTH_DIGEST => HTTP_AUTH_DIGEST,
         Horde_Http::AUTH_GSSNEGOTIATE => HTTP_AUTH_GSSNEG,
         Horde_Http::AUTH_NTLM => HTTP_AUTH_NTLM,
-    );
+    ];
 
     /**
      * Constructor
      *
      * @throws Horde_Http_Exception
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         if (!class_exists('HttpRequest', false)) {
             throw new Horde_Http_Exception('The pecl_http extension is not installed. See http://php.net/http.install');
@@ -62,7 +63,7 @@ class Horde_Http_Request_Peclhttp extends Horde_Http_Request_PeclhttpBase
             throw new Horde_Http_Exception('Method ' . $this->method . ' not supported.');
         }
 
-        $httpRequest = new HttpRequest((string)$this->uri, constant('HTTP_METH_' . $this->method));
+        $httpRequest = new HttpRequest((string) $this->uri, constant('HTTP_METH_' . $this->method));
 
         $data = $this->data;
         if (is_array($data)) {
@@ -80,13 +81,13 @@ class Horde_Http_Request_Peclhttp extends Horde_Http_Request_PeclhttpBase
         try {
             $httpResponse = $httpRequest->send();
         } catch (HttpException $e) {
-            if (isset($e->innerException)){
+            if (isset($e->innerException)) {
                 throw new Horde_Http_Exception($e->innerException);
             } else {
                 throw new Horde_Http_Exception($e);
             }
         }
 
-        return new Horde_Http_Response_Peclhttp((string)$this->uri, $httpResponse);
+        return new Horde_Http_Response_Peclhttp((string) $this->uri, $httpResponse);
     }
 }

--- a/lib/Horde/Http/Request/Peclhttp2.php
+++ b/lib/Horde/Http/Request/Peclhttp2.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -28,29 +29,29 @@ class Horde_Http_Request_Peclhttp2 extends Horde_Http_Request_PeclhttpBase
      *
      * @var array
      */
-    protected $_httpAuthSchemes = array(
+    protected $_httpAuthSchemes = [
         Horde_Http::AUTH_ANY => \http\Client\Curl\AUTH_ANY,
         Horde_Http::AUTH_BASIC => \http\Client\Curl\AUTH_BASIC,
         Horde_Http::AUTH_DIGEST => \http\Client\Curl\AUTH_DIGEST,
         Horde_Http::AUTH_GSSNEGOTIATE => \http\Client\Curl\AUTH_GSSNEG,
         Horde_Http::AUTH_NTLM => \http\Client\Curl\AUTH_NTLM,
-    );
+    ];
 
     /**
      * Map of proxy types from Horde_Http to implementation specific constants.
      * @var array
      */
-    protected $_proxyTypes = array(
+    protected $_proxyTypes = [
         Horde_Http::PROXY_SOCKS4 => \http\Client\Curl\PROXY_SOCKS4,
-        Horde_Http::PROXY_SOCKS5 => \http\Client\Curl\PROXY_SOCKS5
-    );
+        Horde_Http::PROXY_SOCKS5 => \http\Client\Curl\PROXY_SOCKS5,
+    ];
 
     /**
      * Constructor
      *
      * @throws Horde_Http_Exception
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         if (!class_exists('\http\Client', false)) {
             throw new Horde_Http_Exception('The pecl_http extension is not installed. See http://php.net/http.install');
@@ -68,9 +69,9 @@ class Horde_Http_Request_Peclhttp2 extends Horde_Http_Request_PeclhttpBase
     public function send()
     {
         // at this time only the curl driver is supported
-        $client = new \http\Client('curl');
+        $client = new http\Client('curl');
 
-        $body = new \http\Message\Body();
+        $body = new http\Message\Body();
         $data = $this->data;
         if (is_array($data)) {
             $body->addForm($data);
@@ -78,7 +79,7 @@ class Horde_Http_Request_Peclhttp2 extends Horde_Http_Request_PeclhttpBase
             $body->append($data);
         }
 
-        $httpRequest = new \http\Client\Request($this->method, (string)$this->uri, $this->headers, $body);
+        $httpRequest = new http\Client\Request($this->method, (string) $this->uri, $this->headers, $body);
 
         $client->setOptions($this->_httpOptions());
 
@@ -87,10 +88,10 @@ class Horde_Http_Request_Peclhttp2 extends Horde_Http_Request_PeclhttpBase
         try {
             $client->send();
             $httpResponse = $client->getResponse($httpRequest);
-        } catch (\http\Exception $e) {
+        } catch (http\Exception $e) {
             throw new Horde_Http_Exception($e);
         }
 
-        return new Horde_Http_Response_Peclhttp2((string)$this->uri, $httpResponse);
+        return new Horde_Http_Response_Peclhttp2((string) $this->uri, $httpResponse);
     }
 }

--- a/lib/Horde/Http/Request/PeclhttpBase.php
+++ b/lib/Horde/Http/Request/PeclhttpBase.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -28,14 +29,14 @@ abstract class Horde_Http_Request_PeclhttpBase extends Horde_Http_Request_Base
      *
      * @var array
      */
-    protected $_httpAuthSchemes = array();
+    protected $_httpAuthSchemes = [];
 
     /**
      * Map of proxy types from Horde_Http to implementation specific constants.
      *
      * @var array
      */
-    protected $_proxyTypes = array();
+    protected $_proxyTypes = [];
 
     /**
      * Translates a Horde_Http::AUTH_* constant to implementation specific
@@ -79,16 +80,16 @@ abstract class Horde_Http_Request_PeclhttpBase extends Horde_Http_Request_Base
     protected function _httpOptions()
     {
         // Set options
-        $httpOptions = array(
+        $httpOptions = [
             'headers' => $this->headers,
-            'redirect' => (int)$this->redirects,
-            'ssl' => array(
+            'redirect' => (int) $this->redirects,
+            'ssl' => [
                 'verifypeer' => $this->verifyPeer,
-                'verifyhost' => $this->verifyPeer
-            ),
+                'verifyhost' => $this->verifyPeer,
+            ],
             'timeout' => $this->timeout,
-            'useragent' => $this->userAgent
-        );
+            'useragent' => $this->userAgent,
+        ];
 
         // Proxy settings
         if ($this->proxyServer) {
@@ -102,7 +103,7 @@ abstract class Horde_Http_Request_PeclhttpBase extends Horde_Http_Request_Base
             }
             if ($this->proxyType == Horde_Http::PROXY_SOCKS4 || $this->proxyType == Horde_Http::PROXY_SOCKS5) {
                 $httpOptions['proxytype'] = $this->_proxyType();
-            } else if ($this->proxyType != Horde_Http::PROXY_HTTP) {
+            } elseif ($this->proxyType != Horde_Http::PROXY_HTTP) {
                 throw new Horde_Http_Exception(sprintf('Proxy type %s not supported by this request type!', $this->proxyType));
             }
         }

--- a/lib/Horde/Http/Response/Base.php
+++ b/lib/Horde/Http/Response/Base.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -20,6 +21,7 @@
  * @license   http://www.horde.org/licenses/bsd BSD
  * @package   Http
  */
+#[AllowDynamicProperties]
 abstract class Horde_Http_Response_Base
 {
     /**
@@ -81,7 +83,7 @@ abstract class Horde_Http_Response_Base
             // start over.
             if (preg_match('/^HTTP\/(\d.\d) (\d{3})/', $headerLine, $httpMatches)) {
                 $this->httpVersion = $httpMatches[1];
-                $this->code = (int)$httpMatches[2];
+                $this->code = (int) $httpMatches[2];
                 $this->_headers = new Horde_Support_CaseInsensitiveArray();
                 $lastHeader = null;
             }
@@ -96,7 +98,7 @@ abstract class Horde_Http_Response_Base
 
                 if ($tmp = $this->_headers[$headerName]) {
                     if (!is_array($tmp)) {
-                        $tmp = array($tmp);
+                        $tmp = [$tmp];
                     }
                     $tmp[] = $headerValue;
                     $headerValue = $tmp;
@@ -104,8 +106,8 @@ abstract class Horde_Http_Response_Base
 
                 $this->_headers[$headerName] = $headerValue;
                 $lastHeader = $headerName;
-            } elseif (preg_match("|^\s+(.+)$|", $headerLine, $m) &&
-                      !is_null($lastHeader)) {
+            } elseif (preg_match("|^\s+(.+)$|", $headerLine, $m)
+                      && !is_null($lastHeader)) {
                 if (is_array($this->_headers[$lastHeader])) {
                     $tmp = $this->_headers[$lastHeader];
                     end($tmp);

--- a/lib/Horde/Http/Response/Curl.php
+++ b/lib/Horde/Http/Response/Curl.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -27,7 +28,7 @@ class Horde_Http_Response_Curl extends Horde_Http_Response_Base
      *
      * @var array
      */
-    protected $_info = array();
+    protected $_info = [];
 
     /**
      * Response body.

--- a/lib/Horde/Http/Response/Fopen.php
+++ b/lib/Horde/Http/Response/Fopen.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -37,7 +38,7 @@ class Horde_Http_Response_Fopen extends Horde_Http_Response_Base
     /**
      * Constructor.
      */
-    public function __construct($uri, $stream, $headers = array())
+    public function __construct($uri, $stream, $headers = [])
     {
         $this->uri = $uri;
         $this->_stream = $stream;

--- a/lib/Horde/Http/Response/Mock.php
+++ b/lib/Horde/Http/Response/Mock.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -32,7 +33,7 @@ class Horde_Http_Response_Mock extends Horde_Http_Response_Base
     /**
      * Constructor
      */
-    public function __construct($uri, $stream, $headers = array())
+    public function __construct($uri, $stream, $headers = [])
     {
         $this->uri = $uri;
         $this->_stream = $stream;

--- a/lib/Horde/Http/Response/Peclhttp.php
+++ b/lib/Horde/Http/Response/Peclhttp.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.

--- a/lib/Horde/Http/Response/Peclhttp2.php
+++ b/lib/Horde/Http/Response/Peclhttp2.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2007-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2007-2026 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (BSD). If you
  * did not receive this file, see http://www.horde.org/licenses/bsd.
@@ -25,7 +26,7 @@ class Horde_Http_Response_Peclhttp2 extends Horde_Http_Response_Base
     /**
      * HttpMessage object.
      *
-     * @var \http\Client\Response
+     * @var http\Client\Response
      */
     protected $_response;
 
@@ -33,18 +34,18 @@ class Horde_Http_Response_Peclhttp2 extends Horde_Http_Response_Base
      * Constructor.
      *
      * @param string                $uri
-     * @param \http\Client\Response $response
+     * @param http\Client\Response $response
      */
-    public function __construct($uri, \http\Client\Response $response)
+    public function __construct($uri, http\Client\Response $response)
     {
         try {
             $info = $response->getTransferInfo();
-        } catch (\http\Exception $e) {
+        } catch (http\Exception $e) {
             throw new Horde_Http_Exception($e);
         }
         try {
             $this->uri = $info->effective_url;
-        } catch (\http\Exception\RuntimeException $e) {
+        } catch (http\Exception\RuntimeException $e) {
             $this->uri = $uri;
         }
 

--- a/src/Client/Mock.php
+++ b/src/Client/Mock.php
@@ -54,8 +54,7 @@ class Mock implements ClientInterface
     {
         $this->streamFactory = $streamFactory ?? new StreamFactory();
         $this->responseFactory = $responseFactory ?? new ResponseFactory();
-        $this->options = $options;
-
+        $this->options = $options ?? new Options();
     }
 
     /**


### PR DESCRIPTION
Add #[AllowDynamicProperties] to legacy Horde_Http_Response_Base for
PHP 8.2+ compatibility. Fix TypeError in PSR-4 Mock client when
constructed without Options argument.

Closes issue horde/Http#4
